### PR TITLE
Add shooting transitions to player states and animations.

### DIFF
--- a/Assets/Scripts/Player/PlayerState/Fall.cs
+++ b/Assets/Scripts/Player/PlayerState/Fall.cs
@@ -12,7 +12,10 @@ public class Fall : State
     }
     public override void HandleInput()
     {
-        
+        if (Input.GetKeyDown(KeyCode.Mouse0))
+        {
+            context.ChangeState(context.shoot);
+        }
     }
     public override void LogicUpdate()
     {

--- a/Assets/Scripts/Player/PlayerState/Jump.cs
+++ b/Assets/Scripts/Player/PlayerState/Jump.cs
@@ -10,7 +10,10 @@ public class Jump : State
     }
     public override void HandleInput()
     {
-        
+        if (Input.GetKeyDown(KeyCode.Mouse0))
+        {
+            context.ChangeState(context.shoot);
+        }
     }
     public override void LogicUpdate()
     {

--- a/Assets/Super Grotto Escape/Characters/Player/Player-idle/player-idle1.controller
+++ b/Assets/Super Grotto Escape/Characters/Player/Player-idle/player-idle1.controller
@@ -82,6 +82,31 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &-7558612544146849321
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: isShooting
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -8805424321198868456}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &-6196781825873630692
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -152,10 +177,10 @@ AnimatorStateMachine:
     m_Position: {x: 630, y: 260, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -8805424321198868456}
-    m_Position: {x: 50, y: -200, z: 0}
+    m_Position: {x: 310, y: -200, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 6728776527985179282}
-    m_Position: {x: 310, y: -200, z: 0}
+    m_Position: {x: 30, y: -200, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -1530381340474949624}
     m_Position: {x: 310, y: 260, z: 0}
@@ -212,6 +237,7 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 8129306046616059428}
+  - {fileID: -7558612544146849321}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -491,6 +517,31 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &1439755899555026366
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: isShooting
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -8805424321198868456}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &2353854808778689129
 AnimatorState:
   serializedVersion: 6
@@ -587,6 +638,7 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 2435085116451396145}
+  - {fileID: 1439755899555026366}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0


### PR DESCRIPTION
Shooting is now accessible during Jump and Fall states by pressing the left mouse button. Corresponding animator transitions for the `isShooting` condition have been added to the Player Idle controller. This integrates shooting mechanics seamlessly into the player's state machine.