### PR TITLE
Add object auto-return with lifetime control to pool

### DIFF
--- a/Assets/Scripts/Enemies/EnemyInterface/EnemyBase.cs
+++ b/Assets/Scripts/Enemies/EnemyInterface/EnemyBase.cs
@@ -91,7 +91,7 @@ public abstract class EnemyBase : MonoBehaviour, IDamageable, IDeathable, IDamag
             movement.enabled = false;
         }
 
-        // collider2D.enabled = false;
+        collider2D.isTrigger = true;
         rb.linearVelocity = Vector2.zero; // Stop all movement
         rb.bodyType = RigidbodyType2D.Kinematic;
         StartCoroutine(BlinkAndDestroy());

--- a/Assets/Scripts/ObjectPooling/GenericObjectPool.cs
+++ b/Assets/Scripts/ObjectPooling/GenericObjectPool.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using System.Collections;
 using System.Collections.Generic;
 
 public class GenericObjectPool<T> where T : MonoBehaviour
@@ -7,10 +8,14 @@ public class GenericObjectPool<T> where T : MonoBehaviour
     private T prefab;
     private Transform parent;
 
-    public GenericObjectPool(T prefab, int initialSize, Transform parent = null)
+    // Thời gian mặc định để đối tượng tồn tại trước khi tự động trả lại vào pool
+    private float defaultLifeTime = 10f;
+
+    public GenericObjectPool(T prefab, int initialSize, Transform parent = null, float defaultLifeTime = 10f)
     {
         this.prefab = prefab;
         this.parent = parent;
+        this.defaultLifeTime = defaultLifeTime;
 
         for (int i = 0; i < initialSize; i++)
         {
@@ -26,7 +31,7 @@ public class GenericObjectPool<T> where T : MonoBehaviour
         return obj;
     }
 
-    public T Get()
+    public T Get(float? lifeTime = null)
     {
         if (pool.Count == 0)
         {
@@ -35,6 +40,18 @@ public class GenericObjectPool<T> where T : MonoBehaviour
 
         T obj = pool.Dequeue();
         obj.gameObject.SetActive(true);
+
+        // Kiểm soát thời gian tồn tại
+        float timeToLive = lifeTime ?? defaultLifeTime;
+        if (timeToLive > 0)
+        {
+            MonoBehaviour monoBehaviour = obj.GetComponent<MonoBehaviour>();
+            if (monoBehaviour != null)
+            {
+                monoBehaviour.StartCoroutine(AutoReturn(obj, timeToLive));
+            }
+        }
+
         return obj;
     }
 
@@ -42,5 +59,14 @@ public class GenericObjectPool<T> where T : MonoBehaviour
     {
         obj.gameObject.SetActive(false);
         pool.Enqueue(obj);
+    }
+
+    private IEnumerator AutoReturn(T obj, float delay)
+    {
+        yield return new WaitForSeconds(delay);
+        if (obj.gameObject.activeSelf) // Chỉ trả về nếu đối tượng vẫn đang hoạt động
+        {
+            Return(obj);
+        }
     }
 }


### PR DESCRIPTION
Introduced a default lifetime mechanism to `GenericObjectPool`, with optional customization per object request. Added an `AutoReturn` coroutine to automatically return inactive objects after the specified time. Also adjusted `EnemyBase` to set colliders as triggers upon destruction.